### PR TITLE
Adding more logs to identify the state, and final summary of ran scripts

### DIFF
--- a/cassandra/src/main/kotlin/com/typeboot/executor/cassandra/CassandraExecutor.kt
+++ b/cassandra/src/main/kotlin/com/typeboot/executor/cassandra/CassandraExecutor.kt
@@ -7,7 +7,6 @@ import com.typeboot.executor.spi.ScriptExecutor
 import com.typeboot.executor.spi.model.ScriptStatement
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.sql.SQLException
 import java.time.Duration
 
 class CassandraExecutor(private val cqlSession: CqlSession, private val timeout: Long, private val consistencyLevel: ConsistencyLevel) : ScriptExecutor {
@@ -23,10 +22,10 @@ class CassandraExecutor(private val cqlSession: CqlSession, private val timeout:
                         .setTimeout(Duration.ofSeconds(timeout))
                         .setConsistencyLevel(consistencyLevel)
                 execute(bounded)
-                LOGGER.info("""event_source=cassandra-executor, task=execute-statement, statement_no=${stmt.serialNumber}, statement="${stmt.content}", result=success """)
-            } catch (se: SQLException) {
-                LOGGER.info("""event_source=cassandra-executor, task=execute-statement, statement_no=${stmt.serialNumber}, statement="${stmt.content}", result=failure""")
-                throw RuntimeException("error executing statements", se)
+                LOGGER.debug("""event_source=cassandra-executor, task=execute-statement, statement_no=${stmt.serialNumber}, statement="${stmt.content}", result=success """)
+            } catch (se: Exception) {
+                LOGGER.error("""event_source=cassandra-executor, task=execute-statement, statement_no=${stmt.serialNumber}, statement="${stmt.content}", error="${se.message}", result=failure""")
+                throw RuntimeException("error executing statements, ${se.message}", se)
             }
         }
         return true

--- a/cassandra/src/main/kotlin/com/typeboot/executor/cassandra/CassandraExecutor.kt
+++ b/cassandra/src/main/kotlin/com/typeboot/executor/cassandra/CassandraExecutor.kt
@@ -22,7 +22,9 @@ class CassandraExecutor(private val cqlSession: CqlSession, private val timeout:
                         .setTimeout(Duration.ofSeconds(timeout))
                         .setConsistencyLevel(consistencyLevel)
                 execute(bounded)
-                LOGGER.debug("""event_source=cassandra-executor, task=execute-statement, statement_no=${stmt.serialNumber}, statement="${stmt.content}", result=success """)
+                if (LOGGER.isDebugEnabled) {
+                    LOGGER.debug("""event_source=cassandra-executor, task=execute-statement, statement_no=${stmt.serialNumber}, statement="${stmt.content}", result=success """)
+                }
             } catch (se: Exception) {
                 LOGGER.error("""event_source=cassandra-executor, task=execute-statement, statement_no=${stmt.serialNumber}, statement="${stmt.content}", error="${se.message}", result=failure""")
                 throw RuntimeException("error executing statements, ${se.message}", se)


### PR DESCRIPTION
- This PR is to add some logs to identify the state of the exuecutor,where it will help to identify which statement cause the executor to fail
- As well it will give the state of all the executed scripts in the logs
- And update some logs that is only require as debug log

**_Below is the log input for successful executor completion_** 

`
main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=prepare-url, url=jdbc:postgresql://localhost:5432/tools
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=jdbc-connection, result=db-initialised
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="create-tracker-schema", result=success
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="create-tracker-table", result=success
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="create-tracker-history-table", result=success
[main] INFO com.typeboot.executor.core.DefaultRunner - event_source=runner-main, task=collect-scripts, total_scripts=4, scripts_to_run=4
[main] INFO com.datastax.oss.driver.internal.core.DefaultMavenCoordinates - DataStax Java driver for Apache Cassandra(R) (com.datastax.oss:java-driver-core) version 4.10.0
[main] INFO com.datastax.oss.driver.internal.core.context.InternalDriverContext - Could not register Graph extensions; this is normal if Tinkerpop was explicitly excluded from classpath
[s0-admin-0] INFO com.datastax.oss.driver.internal.core.time.Clock - Using native clock for microsecond precision
[s0-io-2] WARN com.datastax.oss.driver.api.core.auth.PlainTextAuthProviderBase - [] /127.0.0.1:9042 did not send an authentication challenge; This is suspicious because the driver expects authentication
[s0-io-3] WARN com.datastax.oss.driver.api.core.auth.PlainTextAuthProviderBase - [] /127.0.0.1:9042 did not send an authentication challenge; This is suspicious because the driver expects authentication
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.core.DefaultRunner - event_source=runner-main, task=count-statements-in-file, file_name=V1.0_create_keyspace.cql, total_statements=1
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.core.DefaultRunner - event_source=runner-main, task=count-statements-in-file, file_name=V2.0_create_table.cql, total_statements=1
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.core.DefaultRunner - event_source=runner-main, task=count-statements-in-file, file_name=V3.0_insert_data.cql, total_statements=3
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.core.DefaultRunner - event_source=runner-main, task=count-statements-in-file, file_name=V4.0_insert_data.cql, total_statements=3
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.core.DefaultRunner - event_source=runner-main, task=final-state, result_summary={V1.0_create_keyspace.cql={total_statements=1, statements_ran=1, error_msg=}, V2.0_create_table.cql={total_statements=1, statements_ran=1, error_msg=}, V3.0_insert_data.cql={total_statements=3, statements_ran=3, error_msg=}, V4.0_insert_data.cql={total_statements=3, statements_ran=3, error_msg=}}, message=All scripts ran successfully
[main] INFO com.typeboot.executor.Exec - event_source=executor, task=run-scripts, result=success, time_taken=6, unit=seconds
`

**_Below is the log input for executor error out_** 

`
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.jdbc.JdbcExecutor - event_source=jdbc-executor, task=execute-statement, statement_no=1, script="", result=success
[main] INFO com.typeboot.executor.core.DefaultRunner - event_source=runner-main, task=count-statements-in-file, file_name=V5.0_create_table.cql, total_statements=3
[main] ERROR com.typeboot.executor.cassandra.CassandraExecutor - event_source=cassandra-executor, task=execute-statement, statement_no=5, statement="
CREATE TABLE demodb.emp ( empID int, deptID int, first_name varchar,last_name varchar, PRIMARY KEY (empID, deptID))", error="Object demodb.emp already exists", result=failure
[main] ERROR com.typeboot.executor.Exec - event_source=executor, task=run-scripts, result=failure, time_taken=4, unit=seconds, error={}
java.lang.RuntimeException: error executing statements, result_summary={V1.0_create_keyspace.cql={total_statements=1, statements_ran=1, error_msg=}, V2.0_create_table.cql={total_statements=1, statements_ran=1, error_msg=}, V3.0_insert_data.cql={total_statements=3, statements_ran=3, error_msg=}, V4.0_insert_data.cql={total_statements=3, statements_ran=3, error_msg=}, V5.0_create_table.cql={total_statements=3, statements_ran=2, error_msg=error executing statements, Object demodb.emp already exists}}
        at com.typeboot.executor.core.DefaultRunner.run(Runners.kt:69)
        at com.typeboot.executor.core.Runners$Companion.process(Runners.kt:117)
        at com.typeboot.ExecKt.main(Exec.kt:12)
Caused by: java.lang.RuntimeException: error executing statements, Object demodb.emp already exists
        at com.typeboot.executor.cassandra.CassandraExecutor.executeStatement(CassandraExecutor.kt:28)
        at com.typeboot.executor.core.DefaultRunner.run(Runners.kt:52)
        ... 2 more
Caused by: com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException: Object demodb.emp already exists
        at com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException.copy(AlreadyExistsException.java:65)
        at com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures.getUninterruptibly(CompletableFutures.java:149)
        at com.datastax.oss.driver.internal.core.cql.CqlRequestSyncProcessor.process(CqlRequestSyncProcessor.java:53)
        at com.datastax.oss.driver.internal.core.cql.CqlRequestSyncProcessor.process(CqlRequestSyncProcessor.java:30)
        at com.datastax.oss.driver.internal.core.session.DefaultSession.execute(DefaultSession.java:230)
        at com.datastax.oss.driver.api.core.cql.SyncCqlSession.execute(SyncCqlSession.java:54)
        at com.typeboot.executor.cassandra.CassandraExecutor.executeStatement(CassandraExecutor.kt:24)
        ... 3 more
`
